### PR TITLE
ViewRouteTrips - ensure stop info viewable, closed info windows can be opened again

### DIFF
--- a/beeline-admin/components/TripStopMarker.vue
+++ b/beeline-admin/components/TripStopMarker.vue
@@ -1,7 +1,9 @@
 <template>
-  <GmapMarker :position="f.pointToLatLng(tripStop.stop.coordinates)"
+  <GmapMarker
+    :position="f.pointToLatLng(tripStop.stop.coordinates)"
     :icon="tripStopIcon"
-  />
+    @click="$emit('click', tripStop)"
+    />
 </template>
 
 <script>

--- a/beeline-admin/modals/ViewRouteTrips.vue
+++ b/beeline-admin/modals/ViewRouteTrips.vue
@@ -40,8 +40,12 @@
           />
       </template>
 
-      <gmap-info-window v-if="selectedStop"
-          :position="f.pointToLatLng(selectedStop.stop.coordinates)">
+      <gmap-info-window
+        v-if="selectedStop"
+        :position="f.pointToLatLng(selectedStop.stop.coordinates)"
+        :opened="selectedStop !== undefined"
+        @closeclick="selectedStop = undefined"
+        >
         <div>
           <b>{{selectedStop.stop.description}}</b>
           <br/>
@@ -49,7 +53,12 @@
         </div>
       </gmap-info-window>
 
-      <gmap-info-window v-if="selectedPing" :position="f.pointToLatLng(selectedPing.coordinates)">
+      <gmap-info-window
+        v-if="selectedPing"
+        :position="f.pointToLatLng(selectedPing.coordinates)"
+        :opened="selectedPing !== undefined"
+        @closeclick="selectedPing = undefined"
+        >
         <div>
           <b>{{f.date(selectedPing.time, 'HH:MM:ss')}}</b>
           <br/>


### PR DESCRIPTION
* TripStopMarker - Ensure GmapMarker bubbles click event up to parent
* ViewRouteTrips - Bind gmap-info-window :opened and @closeclicked to ping/stop

NB: Attempt made to implement test for this, but was held back by inability
to properly stub `GmapMarker` and supporting cast. Further help needed to
understand what has to be done

Fixes #340