### PR TITLE
Use embedded txn item metadata where possible

### DIFF
--- a/beeline-admin/pages/routePasses.vue
+++ b/beeline-admin/pages/routePasses.vue
@@ -368,7 +368,7 @@ export default {
             .then(resp => this.processUncommitReason(txn, resp))
             .catch(this.showErrorModal)
         } else if (txn.transaction.type === 'ticketPurchase') {
-          return this.queryTicket(txn)
+          return this.processTicket(txn)
         } else {
           return this.processTransactionItems(txn)
         }
@@ -379,17 +379,9 @@ export default {
       txn.uncommitReason = _.get(paymentItem, 'payment.data.message') || 'Reason is unknown'
       return txn
     },
-    queryTicket (txn) {
-      txn.description = txn.transaction.description
-      const [ticketId] = Object.keys(_.get(txn.notes, 'tickets') || {})
-      const queryOptions = { itemTypes: ['ticketSale', 'ticketSale'], ticketId }
-      return this.axios.get(`/transaction_items?${querystring.stringify(queryOptions)}`)
-          .then(response => {
-            const [ticketSale] = response.data.rows
-            const [tripDate] = ticketSale.ticketSale.boardStop.time.split('T')
-            txn.description = `Trip Date: ${tripDate}`
-            return txn
-          })
+    processTicket (txn) {
+      txn.description = `Trip Date: ${txn.tripDate}`
+      return txn
     },
     processTransactionItems (txn) {
       const {transactionItems} = txn.transaction

--- a/www/templates/bookings-wrs.html
+++ b/www/templates/bookings-wrs.html
@@ -182,6 +182,7 @@
                   </a>
                 </td>
                 <td class="item-description">
+                  <span ng-if="ticket.routePassPurchaseDescription">{{ticket.routePassPurchaseDescription}}<br/></span>
                   <span ng-if="ticket.paymentResource">{{ticket.paymentResource}}<br/></span>
                   <span ng-if="ticket.ticketExpense">{{ticket.ticketExpense.transaction.description}}<br/></span>
                   <span ng-if="ticket.refundResource">{{ticket.refundResource}}<br/></span>


### PR DESCRIPTION
* Bookings - use route pass purchase description if available
* Route Passes - use embedded trip date in txn if available,
instead of fetching from `/transaction_items`

Fixes #341 