### PR TITLE
 Add timeframe filter

### DIFF
--- a/beeline-admin/stores/resources.js
+++ b/beeline-admin/stores/resources.js
@@ -75,7 +75,7 @@ export const storeModule = {
 
     getPings(context, {tripId, options}) {
       return context.rootGetters.axios
-        .get(`${process.env.TRACKING_URL}/trips/${tripId}/pings?` + querystring.stringify(_.pick(options, ['limit'])))
+        .get(`${process.env.TRACKING_URL}/trips/${tripId}/pings?${querystring.stringify(options)}`)
         .then(resp => resp.data.map(postProcessPing))
     },
   }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "left-pad": "^1.1.0",
     "lodash": "^4.11.1",
     "moment": "^2.14.1",
+    "moment-timezone": "^0.5.16",
     "multiple-date-picker": "git+https://github.com/datagovsg/MultipleDatePicker.git#annotations",
     "request": "^2.74.0",
     "title-case": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "vue-async-computed": "^3.3.0",
     "vue-datepicker": "^1.3.0",
     "vue-select": "^2.2.0",
+    "vue-slider-component": "^2.6.2",
     "vue-strap": "git+https://github.com/wffranco/vue-strap.git",
     "vue2-google-maps": "^0.8.0",
     "vuex": "^2.3.1"


### PR DESCRIPTION
* Change the from/to parameters sent to beeline-tracking to be 30mins
before/after the first/last stop in the trip
* Drop in vue-slider-component, wiring it to `pingParameters.timeframe`
* Ensure that the slider component is lazy and only emits values on user mouseup
* Have a copy of this timeframe - `displayedTimeframe`, and wire this both to
changes in `pingParameters.timeframe` as well as the internal value held by the slider
* Use `displayedTimeframe` to indicate the timeframe chosen to the user

Fixes #365 