### PR TITLE
send output of CSS to www/css instead of dist

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -124,6 +124,9 @@ const cssBundle = {
       ]
     }]
   },
+  output: {
+    path: path.resolve('./www/css')
+  },
   plugins: [
     new MiniCssExtractPlugin({
       filename: 'styles.css',


### PR DESCRIPTION
After switching to MiniCSSExtractPlugin in #372  the CSS output was being sent to `dist` instead of `www/css`.

By right this would have caused the browser to fail loading CSS with a 404 error.

However, because the stale version of `www/css/styles.css` was still in the folder, the misconfiguration was not detected.