### PR TITLE
AuthHelper navigates to company page if admin only belongs to one com…

### DIFF
--- a/beeline-admin/components/nav/SuperAdminCompanySelector.vue
+++ b/beeline-admin/components/nav/SuperAdminCompanySelector.vue
@@ -2,16 +2,16 @@
 <select @input="navigateToCompany($event.target.value)"
   class="form-control-condensed">
   <option value="null" :selected="!currentCompany">(All)</option>
-  <option v-for="company in availableCompanies"
-    :key="company.id"
-    :value="company.id" :selected="currentCompany === company.id">
-    {{company.name}}
+  <option v-for="companyId in availableCompanies"
+    :key="companyId"
+    :value="companiesById[companyId]" :selected="currentCompany === companyId">
+    {{companiesById[companyId].name}}
   </option>
 </select>
 </template>
 
 <script>
-import {mapGetters, mapState, mapActions} from 'vuex'
+import {mapGetters, mapState, mapActions, mapMutations} from 'vuex'
 
 export default {
   created () {
@@ -20,32 +20,17 @@ export default {
   computed: {
     ...mapGetters(['axios']),
     ...mapState('shared', ['companies']),
-    ...mapState('auth', ['idToken']),
+    ...mapState('auth', ['idToken', 'availableCompanies']),
     ...mapGetters('shared', ['companiesById']),
 
     currentCompany () {
       return Number(this.$route.params.companyId)
-    },
-
-    availableCompanies () {
-      return this.whoami && this.companies &&
-        (this.whoami.role === 'superadmin'
-          ? this.companies
-          : this.whoami.transportCompanyIds.map(tci => this.companiesById[tci])
-        )
-    }
-  },
-  asyncComputed: {
-    whoami () {
-      if (!this.idToken) {
-        return null
-      }
-      return this.axios.get('/admins/whoami')
-        .then(r => r.data)
     }
   },
   methods: {
+    ...mapMutations('auth', ['setAvailableCompanies']),
     ...mapActions('shared', ['fetch']),
+
     navigateToCompany (id) {
       this.$router.push({
         query: this.$route.query,

--- a/beeline-admin/stores/auth.js
+++ b/beeline-admin/stores/auth.js
@@ -5,6 +5,8 @@ module.exports = {
     isAuthenticated: false,
     idToken: null,
 
+    availableCompanies: null,
+
     loginDialogShown: false,
     initCompleted: false
   }),
@@ -19,6 +21,9 @@ module.exports = {
     },
     showLoginDialog (state, visible) {
       state.loginDialogShown = visible
+    },
+    setAvailableCompanies (state, companyIds) {
+      state.availableCompanies = companyIds
     }
   }
 }


### PR DESCRIPTION
…pany

- AuthHelper is now responsible for fetching the list of companies the admin
  belongs to
- This is then saved in the `auth` store instead of being a state in
  super-admin-company-selector
- super-admin-company-selector gets its list of companies from the `auth` store
- AuthHelper is also responsible for navigating from /c/null/<page> to /c/<companyId>/<page>
- Reason for moving everything into AUthHelper is to ensure that super-admin-company-selector is (almost) a pure component with no side effects
- Side effects (i.e. the unsolicited page navigation) are now moved to the AuthHelper