### PR TITLE
incrementally load the routes in the users page

### DIFF
--- a/beeline-admin/components/users/AllRoutePassesTable.vue
+++ b/beeline-admin/components/users/AllRoutePassesTable.vue
@@ -137,7 +137,6 @@ export default {
 
   computed: {
     ...mapGetters(['axios']),
-    ...mapState('shared', ['allRoutes']),
 
     f: () => filters,
 
@@ -166,10 +165,6 @@ export default {
         }
       }
     }
-  },
-
-  created () {
-    this.fetch(['allRoutes'])
   },
 
   methods: {

--- a/beeline-admin/components/users/AllRoutePassesTable.vue
+++ b/beeline-admin/components/users/AllRoutePassesTable.vue
@@ -16,97 +16,101 @@
       <th class="route-header">Route Price</th>
     </tr>
   </thead>
-  <tbody v-if="routePasses === null || allRoutes === null">
+  <tbody v-if="routePasses === null">
     <tr><td colspan="9"><img src="../../../www/img/spinner.svg" /></td></tr>
   </tbody>
   <tbody v-for="routePass in routePasses" :key="routePass.tag">
-    <template v-if="routesByRouteTag && routesByRouteTag[routePass.tag]"> <!-- wait for routes data to be loaded -->
-      <RouteInfo v-for="(route, index) in routesByRouteTag[routePass.tag]" :key="route.id" :routeId="route.id">
-        <tr slot-scope="routeInfo">
-          <td v-if="index == 0" :rowspan="routesByRouteTag[routePass.tag].length">
-            <button class="btn btn-success btn-sm" @click="showHistory(routePass.tag, routePass.balance)">
-              <span class="glyphicon glyphicon-time" aria-hidden="true"></span>
-              View History
-            </button>
-            <br/>
-            <button class="btn btn-warning btn-sm" @click="$emit('show-issue-credits', routePass)">
-              <span class="glyphicon glyphicon-piggy-bank" aria-hidden="true"></span>
-              Issue passes...
-            </button>
-            <br/>
-            <button class="btn btn-danger btn-sm" @click="$emit('show-expire-credits', routePass)">
-              <span class="glyphicon glyphicon-scissors" aria-hidden="true"></span>
-              Expire passes...
-            </button>
-          </td>
-          <td v-if="index === 0" :rowspan="routesByRouteTag[routePass.tag].length">
-            <ul class="tags"><li class="tags">{{ routePass.tag }}</li></ul>
-          </td>
-          <td v-if="index === 0" :rowspan="routesByRouteTag[routePass.tag].length"
-            class="width-limit-xs">{{ routePass.balance }}</td>
-          <td>
+    <RouteInfo v-for="(route, index) in ((routesByRouteTag && routesByRouteTag[routePass.tag]) || [null])"
+        :key="route ? route.id : index"
+        :routeId="route && route.id">
+      <tr slot-scope="routeInfo">
+        <td v-if="index == 0" :rowspan="f._.get(routesByRouteTag, `${routePass}.length`, 1)">
+          <button class="btn btn-success btn-sm" @click="showHistory(routePass.tag, routePass.balance)">
+            <span class="glyphicon glyphicon-time" aria-hidden="true"></span>
+            View History
+          </button>
+          <br/>
+          <button class="btn btn-warning btn-sm" @click="$emit('show-issue-credits', routePass)">
+            <span class="glyphicon glyphicon-piggy-bank" aria-hidden="true"></span>
+            Issue passes...
+          </button>
+          <br/>
+          <button class="btn btn-danger btn-sm" @click="$emit('show-expire-credits', routePass)">
+            <span class="glyphicon glyphicon-scissors" aria-hidden="true"></span>
+            Expire passes...
+          </button>
+        </td>
+        <td v-if="index === 0" :rowspan="f._.get(routesByRouteTag, `${routePass}.length`, 1)">
+          <ul class="tags"><li class="tags">{{ routePass.tag }}</li></ul>
+        </td>
+        <td v-if="index === 0" :rowspan="f._.get(routesByRouteTag, `${routePass}.length`, 1)"
+          class="width-limit-xs">{{ routePass.balance }}
+        </td>
+
+        <td>
+          <template v-if="route">
             <a :href="`#/c/${companyId}/trips/${route.id}/route`" class="route-label">{{ route.label }}</a>
-          </td>
-          <td class="width-limit-md">
+          </template>
+        </td>
+        <td class="width-limit-md">
+          <table class="borderless" v-if="route">
+            <tr>
+              <td style="width:25%">From:</td>
+              <td>{{ route.from }}</td>
+            </tr>
+            <tr>
+              <td>To:</td>
+              <td>{{ route.to }}</td>
+            </tr>
+          </table>
+        </td>
+        <td class="routes-page">
+          <template v-if="routeInfo">
+            <span class="label route-active"
+              v-if="routeInfo.dates.firstDate.getTime() <= now && now <= routeInfo.dates.lastDate.getTime() + 24*3600*1000">Active</span>
+            <span class="label route-notstarted"
+              v-if="now < routeInfo.dates.firstDate.getTime()">Not Started</span>
+            <span class="label route-ended"
+              v-if="now > routeInfo.dates.lastDate.getTime() + 24*3600*1000">Ended</span>
+          </template>
+        </td>
+        <td class="width-limit-md">
+          <ExpandableArea v-if="f._.get(routeInfo, 'trips[0].tripStops')">
             <table class="borderless">
-              <tr>
-                <td style="width:25%">From:</td>
-                <td>{{ route.from }}</td>
-              </tr>
-              <tr>
-                <td>To:</td>
-                <td>{{ route.to }}</td>
+              <tr v-for="tripStop in routeInfo.trips[0].tripStops.filter(r => r.canBoard)"
+                  :key="tripStop.id">
+                <td class="text-nowrap">
+                  {{f.date(tripStop.time, 'HH:MM')}}
+                </td>
+                <td>
+                  {{tripStop.stop.description}}
+                </td>
               </tr>
             </table>
-          </td>
-          <td class="routes-page">
-            <template v-if="routeInfo">
-              <span class="label route-active"
-                v-if="routeInfo.dates.firstDate.getTime() <= now && now <= routeInfo.dates.lastDate.getTime() + 24*3600*1000">Active</span>
-              <span class="label route-notstarted"
-                v-if="now < routeInfo.dates.firstDate.getTime()">Not Started</span>
-              <span class="label route-ended"
-                v-if="now > routeInfo.dates.lastDate.getTime() + 24*3600*1000">Ended</span>
-            </template>
-          </td>
-          <td class="width-limit-md">
-            <ExpandableArea v-if="f._.get(routeInfo, 'trips[0].tripStops')">
-              <table class="borderless">
-                <tr v-for="tripStop in routeInfo.trips[0].tripStops.filter(r => r.canBoard)"
-                    :key="tripStop.id">
-                  <td class="text-nowrap">
-                    {{f.date(tripStop.time, 'HH:MM')}}
-                  </td>
-                  <td>
-                    {{tripStop.stop.description}}
-                  </td>
-                </tr>
-              </table>
-            </ExpandableArea>
-          </td>
-          <td class="width-limit-md">
-            <ExpandableArea v-if="f._.get(routeInfo, 'trips[0].tripStops')">
-              <table class="borderless">
-                <tr v-for="tripStop in routeInfo.trips[0].tripStops.filter(r => r.canAlight)"
-                    :key="tripStop.id">
-                  <td class="text-nowrap">
-                    {{f.date(tripStop.time, 'HH:MM')}}
-                  </td>
-                  <td>
-                    {{tripStop.stop.description}}
-                  </td>
-                </tr>
-              </table>
-            </ExpandableArea>
-          </td>
-          <td class="width-limit-xs">
-            <template v-if="f._.get(routeInfo, 'indicativeTrip')">
-              {{ f.number(routeInfo.indicativeTrip.lastPrice, '#,##0.00') }}
-            </template>
-          </td>
-        </tr>
-      </RouteInfo>
-    </template>
+          </ExpandableArea>
+        </td>
+        <td class="width-limit-md">
+          <ExpandableArea v-if="f._.get(routeInfo, 'trips[0].tripStops')">
+            <table class="borderless">
+              <tr v-for="tripStop in routeInfo.trips[0].tripStops.filter(r => r.canAlight)"
+                  :key="tripStop.id">
+                <td class="text-nowrap">
+                  {{f.date(tripStop.time, 'HH:MM')}}
+                </td>
+                <td>
+                  {{tripStop.stop.description}}
+                </td>
+              </tr>
+            </table>
+          </ExpandableArea>
+        </td>
+        <td class="width-limit-xs">
+          <template v-if="f._.get(routeInfo, 'indicativeTrip')">
+            {{ f.number(routeInfo.indicativeTrip.lastPrice, '#,##0.00') }}
+          </template>
+        </td>
+      </tr>
+    </RouteInfo>
   </tbody>
 </table>
 </template>
@@ -126,7 +130,8 @@ export default {
 
   data () {
     return {
-      routePasses: null
+      routePasses: null,
+      routesByRouteTag: {},
     }
   },
 
@@ -138,22 +143,6 @@ export default {
 
     now () {
       return Date.now()
-    },
-
-    companyRoutes () {
-      return this.allRoutes && this.allRoutes.filter(r =>
-        r.transportCompanyId === Number(this.companyId))
-    },
-
-    routesByRouteTag () {
-      return this.routePasses && this.companyRoutes &&
-        this.routePasses.reduce(
-          (acc, rp) => {
-            acc[rp.tag] = this.companyRoutes.filter(r => r.tags.includes(rp.tag))
-            return acc
-          },
-          {}
-        )
     },
 
     displayedRoutes () {
@@ -185,6 +174,7 @@ export default {
 
   methods: {
     ...mapActions('shared', ['fetch']),
+    ...mapActions('resources', ['getRoutes']),
     ...mapActions('modals', ['showModal', 'showErrorModal', 'flash']),
 
     requery () {
@@ -193,6 +183,23 @@ export default {
           .then((response) => {
             if (promise === this.$routePassesPromise) {
               this.routePasses = response.data
+              this.routesByRouteTag = {}
+            }
+          })
+          .then(() => { // load the routes by route pass
+            for (let routePass of this.routePasses) {
+              this.getRoutes({
+                transportCompanyId: this.companyId,
+                tags: JSON.stringify([routePass.tag])
+              })
+                .then((routes) => {
+                  if (promise === this.$routePassesPromise) {
+                    this.routesByRouteTag = {
+                      ...this.routesByRouteTag,
+                      [routePass.tag]: routes
+                    }
+                  }
+                })
             }
           })
     },

--- a/beeline-admin/components/users/AllRoutePassesTable.vue
+++ b/beeline-admin/components/users/AllRoutePassesTable.vue
@@ -116,7 +116,7 @@
 </template>
 
 <script>
-import {mapGetters, mapActions, mapState} from 'vuex'
+import {mapGetters, mapActions} from 'vuex'
 
 import ExpandableArea from '@/components/ExpandableArea.vue'
 import RouteInfo from '@/components/users/RouteInfo'
@@ -131,7 +131,7 @@ export default {
   data () {
     return {
       routePasses: null,
-      routesByRouteTag: {},
+      routesByRouteTag: {}
     }
   },
 


### PR DESCRIPTION
The previous method, where we waited for `allRoutes` to load, is simply too slow.

So we load the routes on demand instead.