### PR TITLE
fix route selector display of multiple routes

### DIFF
--- a/beeline-admin/components/PromotionCriterionEditor.vue
+++ b/beeline-admin/components/PromotionCriterionEditor.vue
@@ -34,10 +34,11 @@
     <div v-if="value.type === 'limitByRoute'">
       <label>
         Routes
-        <RouteSelector :multiple="true" class="form-control"
+        <RouteSelector :multiple="true"
           :companyId="companyId"
           :value="paramCache.limitByRoute.routeIds"
           @input="updateParam('routeIds', $event)"
+          class="route-selector"
           />
       </label>
     </div>
@@ -145,6 +146,12 @@
     <hr/>
   </div>
 </template>
+<style scoped>
+.route-selector {
+  min-width: 300px;
+}
+</style>
+
 <script>
 const _ = require('lodash')
 const titleCase = require('title-case')

--- a/beeline-admin/components/RouteSelector.vue
+++ b/beeline-admin/components/RouteSelector.vue
@@ -16,7 +16,7 @@
             {{routesById[routeId].name}}
           </template>
           <template v-else>
-            Route #{{s.entry}}
+            Route #{{routeId}}
           </template>
         </div>
       </template>
@@ -33,6 +33,7 @@
 
     <span slot="option-template" slot-scope="s">
       <div
+        class="route-selector-option-template"
         :class="{
           selected: isSelected(value, s.entry.id)
         }"
@@ -170,5 +171,8 @@ export default {
     white-space: nowrap;
     overflow: hidden;
   }
+}
+.route-selector-option-template {
+  min-width: 200px;
 }
 </style>


### PR DESCRIPTION
- when multiple routes can be selected (multiple=true)
  the whole array is rendered for unknown routes instead of just
  the route label and name. This commit fixes this problem

- Define a minimum width for the promotion criterion editor
  so that when nothing is selected, it still looks half-decent