### PR TITLE
Batched extend routes

### DIFF
--- a/beeline-admin/pages/extend-routes.vue
+++ b/beeline-admin/pages/extend-routes.vue
@@ -66,7 +66,7 @@
         <tr>
           <th></th>
           <th></th>
-          <th v-for="month in months" :key="month.date" :colspan="month.colspan" class="new-month">
+          <th v-for="month in months" :key="month.date.getTime()" :colspan="month.colspan" class="new-month">
             {{f.monthNames(month.date.getUTCMonth())}}
           </th>
         </tr>

--- a/beeline-admin/pages/extend-routes.vue
+++ b/beeline-admin/pages/extend-routes.vue
@@ -484,7 +484,7 @@ export default {
 
         try {
           // Do it batches of 5
-          for (let days of batched(
+          for (let days of _.chunk(
             daysToExtend.filter(day => !route.tripsByDate[day.date.getTime()]),
             5
           )) {
@@ -513,18 +513,6 @@ export default {
   }
 }
 
-function batched (arr, n) {
-  return arr.reduce(
-    (acc, obj) => {
-      if (acc.length === 0 || acc[acc.length - 1].length === n) {
-        acc.push([])
-      }
-      acc[acc.length - 1].push(obj)
-      return acc
-    },
-    []
-  )
-}
 </script>
 
 <style lang="scss">

--- a/beeline-admin/pages/extend-routes.vue
+++ b/beeline-admin/pages/extend-routes.vue
@@ -506,7 +506,9 @@ export default {
         this.extendJobs.done++
       }
 
-      window.location.reload()
+      await this.alert({
+        title: `${routesToExtend.length} routes successfully extended!`
+      })
     }
   }
 }


### PR DESCRIPTION
Adds some features that Swee Chin mentioned:
- If route extension fails at any time, tell the user about the error (using a modals::alert)
- Instead of creating all trips at once, throttle it to 5 at a time

Also, a refactor from `computed.routePromise` to `methods.requery`