### PR TITLE
deselect route and dates after extension

### DIFF
--- a/beeline-admin/pages/extend-routes.vue
+++ b/beeline-admin/pages/extend-routes.vue
@@ -512,6 +512,13 @@ export default {
       await this.alert({
         title: `${routesToExtend.length} routes successfully extended!`
       })
+
+      for (let day of this.days) {
+        day.selected = false
+      }
+      for (let route of this.filteredRoutes) {
+        route.selected = false
+      }
     }
   }
 }


### PR DESCRIPTION
According to @chuasweechin he doesn't want to have to manually deselect routes after he has extended them